### PR TITLE
Adds dependencies & starts build instructions for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,59 @@
 # edp-people-picker
 
 Demo for Travelers
+
+## Running this project locally
+
+### Dependencies
+
+- [Node.js](https://nodejs.org/en)
+- [Express](https://expressjs.com/)
+- [Vite](https://vitejs.dev/)
+- [MongoDB](https://www.mongodb.com/)
+
+### How to run locally
+
+1. Clone this repository
+
+2. Change into the `edp-people-picker` directory
+
+```bash
+$ cd edp-people-picker
+```
+
+3. Install node module dependencies
+
+```bash
+$ npm install
+```
+
+4. Change into the `edp-people-picker/react-app` directory and install node
+   module dependencies for the React app
+
+```bash
+$ cd react-app
+$ npm install
+```
+5. Build `dist` files
+
+```bash
+$ npm run build
+```
+
+6. Change back into root `edp-people-picker` directory
+
+```bash
+$ cd ..
+```
+
+7. In a seperate terminal, start your mongo server
+
+```bash
+$ mongod
+```
+
+8. In the first terminal, import data from `db.json`
+
+```bash
+$ mongoimport --db edp --collection people --file db.json --jsonArray
+```

--- a/README.md
+++ b/README.md
@@ -39,31 +39,30 @@ $ npm install
 ```bash
 $ npm run build
 ```
+6. Copy the generated `dist` directory into the `public` directory
 
-6. Change back into root `edp-people-picker` directory
+7. Change back into root `edp-people-picker` directory
 
 ```bash
 $ cd ..
 ```
 
-7. In a seperate terminal, start your mongo server
+8. Open a second terminal. Start your MongoDB server there.
 
 ```bash
 $ mongod
 ```
 
-8. In the first terminal, import data from `db.json`
+9. Back in the first terminal, import data from `db.json`
 
 ```bash
 $ mongoimport --db edp --collection people --file db.json --jsonArray
 ```
 
-
-....
-
-
-9. Start the web server
+10. Start the web server
 
 ```bash
 $ npm run start
 ```
+
+11. Navigate to `http://localhost:3500/index.html`

--- a/README.md
+++ b/README.md
@@ -57,3 +57,13 @@ $ mongod
 ```bash
 $ mongoimport --db edp --collection people --file db.json --jsonArray
 ```
+
+
+....
+
+
+9. Start the web server
+
+```bash
+$ npm run start
+```

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $ mongod
 9. Back in the first terminal, import data from `db.json`
 
 ```bash
-$ mongoimport --db edp --collection people --file db.json --jsonArray
+$ mongoimport --db edp --collection people --file mongodb-data.json --jsonArray
 ```
 
 10. Start the web server

--- a/db.json
+++ b/db.json
@@ -1,5 +1,4 @@
-{
-  "people": [
+[    
     {
       "id": 1,
       "name": "Brian Murray",
@@ -105,5 +104,4 @@
       "name": "Ola Ekdahl",
       "picture": "/images/ola.jpg"
     }
-  ]
-}
+]

--- a/db.json
+++ b/db.json
@@ -1,4 +1,5 @@
-[    
+{
+  "people": [
     {
       "id": 1,
       "name": "Brian Murray",
@@ -104,4 +105,5 @@
       "name": "Ola Ekdahl",
       "picture": "/images/ola.jpg"
     }
-]
+  ]
+}

--- a/mongodb-data.json
+++ b/mongodb-data.json
@@ -1,107 +1,107 @@
-[
-  {
-    "id": 1,
-    "name": "Brian Murray",
-    "picture": "/images/Brian.jpeg"
-  },
-  {
-    "id": 2,
-    "name": "Daniel Janikowski",
-    "picture": "/images/Dan.png"
-  },
-  {
-    "id": 3,
-    "name": "Jared Kozar",
-    "picture": "/images/Jared.png"
-  },
-  {
-    "id": 4,
-    "name": "April Breen",
-    "picture": "/images/april_and_JCP.png"
-  },
-  {
-    "id": 5,
-    "name": "Alessandro Gagarin",
-    "picture": "/images/Alessandro.png"
-  },
-  {
-    "id": 6,
-    "name": "Aaron Wang",
-    "picture": "/images/Aaron.png"
-  },
-  {
-    "id": 7,
-    "name": "Nicky Rathe",
-    "picture": "/images/Nicky.jpg"
-  },
-  {
-    "id": 8,
-    "name": "Ben Lee",
-    "picture": "/images/Ben.png"
-  },
-  {
-    "id": 9,
-    "name": "Hannah Good",
-    "picture": "/images/Hannah.png"
-  },
-  {
-    "id": 10,
-    "name": "Michael Ambrose",
-    "picture": "/images/Michael.png"
-  },
-  {
-    "id": 11,
-    "name": "Matthew Jones",
-    "picture": "/images/Matt.png"
-  },
-  {
-    "id": 12,
-    "name": "Calder Waugh",
-    "picture": "/images/Calder.png"
-  },
-  {
-    "id": 13,
-    "name": "Josh Hoang",
-    "picture": "/images/Josh.jpeg"
-  },
-  {
-    "id": 14,
-    "name": "Zachary Mowry",
-    "picture": "/images/Zach.png"
-  },
-  {
-    "id": 15,
-    "name": "Jacob Boyce",
-    "picture": "/images/Jacob.png"
-  },
-  {
-    "id": 16,
-    "name": "Yiran Fitzpatrick",
-    "picture": "/images/Yiran.jpg"
-  },
-  {
-    "id": 17,
-    "name": "Craig O'Loughlin",
-    "picture": "/images/Craig.png"
-  },
-  {
-    "id": 18,
-    "name": "Kays Cetin",
-    "picture": ""
-  },
-  {
-    "id": 19,
-    "name": "Allie Hanson",
-    "picture": "/images/Allie.jpg"
-  },
-  {
-    "id": 20,
-    "name": "Rap",
-    "picture": "/images/Rap.png"
-  },
-  {
-    "id": 21,
-    "name": "Ola Ekdahl",
-    "picture": "/images/ola.jpg"
-  }
+[    
+    {
+      "id": 1,
+      "name": "Brian Murray",
+      "picture": "/images/Brian.jpeg"
+    },
+    {
+      "id": 2,
+      "name": "Daniel Janikowski",
+      "picture": "/images/Dan.png"
+    },
+    {
+      "id": 3,
+      "name": "Jared Kozar",
+      "picture": "/images/Jared.png"
+    },
+    {
+      "id": 4,
+      "name": "April Breen",
+      "picture": "/images/april_and_JCP.png"
+    },
+    {
+      "id": 5,
+      "name": "Alessandro Gagarin",
+      "picture": "/images/Alessandro.png"
+    },
+    {
+      "id": 6,
+      "name": "Aaron Wang",
+      "picture": "/images/Aaron.png"
+    },
+    {
+      "id": 7,
+      "name": "Nicky Rathe",
+      "picture": "/images/Nicky.jpg"
+    },
+    {
+      "id": 8,
+      "name": "Ben Lee",
+      "picture": "/images/Ben.png"
+    },
+    {
+      "id": 9,
+      "name": "Hannah Good",
+      "picture": "/images/Hannah.png"
+    },
+    {
+      "id": 10,
+      "name": "Michael Ambrose",
+      "picture": "/images/MichaelAmbrose.jpg"
+    },
+    {
+      "id": 11,
+      "name": "Matthew Jones",
+      "picture": "/images/Matt.png"
+    },
+    {
+      "id": 12,
+      "name": "Calder Waugh",
+      "picture": "/images/Calder.png"
+    },
+    {
+      "id": 13,
+      "name": "Josh Hoang",
+      "picture": "/images/Josh.jpeg"
+    },
+    {
+      "id": 14,
+      "name": "Zachary Mowry",
+      "picture": "/images/Zach.png"
+    },
+    {
+      "id": 15,
+      "name": "Jacob Boyce",
+      "picture": "/images/Jacob.png"
+    },
+    {
+      "id": 16,
+      "name": "Yiran Fitzpatrick",
+      "picture": "/images/Yiran.jpg"
+    },
+    {
+      "id": 17,
+      "name": "Craig O'Loughlin",
+      "picture": "/images/Craig.png"
+    },
+    {
+      "id": 18,
+      "name": "Kays Cetin",
+      "picture": ""
+    },
+    {
+      "id": 19,
+      "name": "Allie Hanson",
+      "picture": "/images/Allie.jpg"
+    },
+    {
+      "id": 20,
+      "name": "Rap",
+      "picture": "/images/Rap.png"
+    },
+    {
+      "id": 21,
+      "name": "Ola Ekdahl",
+      "picture": "/images/ola.jpg"
+    }
 ]


### PR DESCRIPTION
Tries to add dependency list and local build instructions for developers. Not sure if the build instructions are more complicated than they need to be, since I felt like I had to do `npm install` in both the `react-app` and `edp-people-picker` directories. Maybe only the steps are necessary in the `react-app` directory, but that doesn't seem like the case since all the Mongo client stuff is in `main.js`. 

With steps 7 & 8, I think I am a bit stuck on how to correctly populate the Mongo server, since I believe I am getting an error on one of the GET requests when I actually try to run the web server in step 9. Plus, I think something needs to happen w/ a directory `/api/people` that I am missing and might need to create? Perhaps we can talk about this during class if that seems like a reasonable use of time, otherwise maybe you can leave feedback here. 

It is also the case that I am working on my personal laptop rather than the lab machine, so I could have missed an additional step.